### PR TITLE
Flip the check to be truthy when null

### DIFF
--- a/src/resizeObserver.js
+++ b/src/resizeObserver.js
@@ -6,7 +6,7 @@ export default (domElement, callback) => {
     return () => {}
   }
 
-  if (global.ResizeObserver != null) {
+  if (global.ResizeObserver == null) {
     let recordedSize = {}
 
     const onChange = () => {


### PR DESCRIPTION
We only want it to bypass this if-statement if `global.ResizeObserver` is a thing.